### PR TITLE
Update ES to 1.7.6 and use default-jre-headless

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,10 +4,9 @@
 elasticsearch_user: elasticsearch
 elasticsearch_group: elasticsearch
 elasticsearch_download_url: https://download.elasticsearch.org/elasticsearch/elasticsearch
-elasticsearch_version: 1.7.5
-elasticsearch_apt_repos:
-  - 'ppa:webupd8team/java'
-elasticsearch_apt_java_package: oracle-java8-installer
+elasticsearch_version: 1.7.6
+elasticsearch_apt_repos: []
+elasticsearch_apt_java_package: default-jre-headless
 elasticsearch_apt_dependencies:
   - htop
   - ntp

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,11 +16,6 @@
     update_cache: "yes"
   with_items: "{{ elasticsearch_apt_repos }}"
 
-# Accept Oracle license
-- name: Accept Oracle license prior JDK installation
-  shell: echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections; echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections creates=/usr/lib/jvm/java-7-oracle
-  when: elasticsearch_install_java
-
 # Install Java
 - name: Install dependencies
   apt:


### PR DESCRIPTION
This PR addresses two problems:
- Default ES version is 1.7.5 instead of 1.7.6 (the latest 1.x release available)
- The default JVM installed in this role is propietary and unavailable (see #3 and #5)