### PR TITLE
Add elasticsearch 5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,11 +144,33 @@ elasticsearch_custom_jars:
 ### Configuring Thread Pools
 Elasticsearch [thread pools](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-threadpool.html) can be configured using the `elasticsearch_thread_pools` list variable:
 
+For Elasticsearch version < 5:
+
 ```
 elasticsearch_thread_pools:
   - "threadpool.bulk.type: fixed"
   - "threadpool.bulk.size: 50"
   - "threadpool.bulk.queue_size: 1000"
+```
+
+For Elasticsearch version 5, the above setting as changed a bit:
+
+```
+elasticsearch_thread_pools:
+  - "thread_pool.bulk.size: 2"
+  - "thread_pool.bulk.queue_size: 1000"
+
+```
+
+**Note: For Elasticsearch version greater than 5, The `bulk.size` limit is the number of cores + 1.**
+
+For Elasticsearch 6, the above setting is compatible, but will be removed in 7.0.0 (See https://www.elastic.co/guide/en/elasticsearch/reference/6.x/breaking-changes-6.3.html#_renaming_the_bulk_thread_pool). The `bulk` thread pool has been renamed to the `write` thread pool, and this is the equivalent settings:
+
+```
+elasticsearch_thread_pools:
+  - "thread_pool.write.size: 2"
+  - "thread_pool.write.queue_size: 1000"
+
 ```
 
 ### Enabling Sematext SPM

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,10 @@ elasticsearch_service_startonboot: yes
 elasticsearch_service_state: started
 elasticsearch_network_bind_host: "127.0.0.1"
 
+# Elasticsearch 5 Ansible Variables
+
+elasticsearch5_download_url: https://artifacts.elastic.co/downloads/elasticsearch
+
 # Non-Elasticsearch Defaults
 apt_cache_valid_time: 300 # seconds between "apt-get update" calls.
 elasticsearch_install_java: "true"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,7 @@
     state: "present"
     update_cache: "yes"
     cache_valid_time: "{{apt_cache_valid_time}}"
+  when: "ansible_distribution_version is version_compare('16.04', '<=')"
 
 - name: Update repositories
   apt_repository:
@@ -42,12 +43,23 @@
 # Check whether we have aleady installed the same version
 - shell: if [ -e /usr/share/elasticsearch/lib/elasticsearch-{{ elasticsearch_version }}.jar ]; then echo yes; else echo no; fi;
   register: version_exists
-  always_run: True
+  check_mode: no
 
-# Download deb if needed
-- name: Download Elasticsearch deb
+# Download deb if needed (ES version < 5.0.0)
+- name: Download Elasticsearch deb (ES version < 5.0.0)
   get_url: url={{ elasticsearch_download_url }}/elasticsearch-{{ elasticsearch_version }}.deb dest=/tmp/elasticsearch-{{ elasticsearch_version }}.deb mode=0440
-  when: version_exists.stdout == 'no'
+  when: version_exists.stdout == 'no' and elasticsearch_version is version_compare('5.0', '<')
+
+# Download deb if needed (ES version >= 5.0.0)
+- name: Download Elasticsearch deb (ES version >= 5.0.0)
+  get_url: url={{ elasticsearch5_download_url }}/elasticsearch-{{ elasticsearch_version }}.deb dest=/tmp/elasticsearch-{{ elasticsearch_version }}.deb mode=0440
+  when: version_exists.stdout == 'no' and elasticsearch_version is version_compare('5.0', '>=')
+
+# Define auxiliar variable for ES version >= 6.0.0
+- name: Define ESversionGt5 variable when ES version >= 6.0.0
+  set_fact:
+    ESversionGt5: true
+  when: elasticsearch_version is version_compare('6.0', '>=')
 
 # Uninstall previous version if applicable
 - name: Uninstalling previous version if applicable
@@ -116,12 +128,22 @@
   when: (elasticsearch_plugin_marvel_version is defined)
 
 # Configure Elasticsearch Node
-- name: Configuring Elasticsearch Node
+- name: Configuring Elasticsearch Node (ES version < 5.0)
   template: src=elasticsearch.yml.j2 dest={{ elasticsearch_conf_dir }}/elasticsearch.yml owner={{ elasticsearch_user }} group={{ elasticsearch_group }} mode=0644
-  when: elasticsearch_conf_dir is defined
+  when: elasticsearch_conf_dir is defined and elasticsearch_version is version_compare('5.0', '<')
   notify: Restart Elasticsearch
 
 - template: src=elasticsearch.default.j2 dest=/etc/default/elasticsearch owner={{ elasticsearch_user }} group={{ elasticsearch_group }} mode=0644
+  when: elasticsearch_version is version_compare('5.0', '<')
+  notify: Restart Elasticsearch
+
+- name: Configuring Elasticsearch Node (ES version >5.0)
+  template: src=elasticsearch5.yml.j2 dest={{ elasticsearch_conf_dir }}/elasticsearch.yml owner={{ elasticsearch_user }} group={{ elasticsearch_group }} mode=0644
+  when: elasticsearch_conf_dir is defined and elasticsearch_version is version_compare('5.0', '>=')
+  notify: Restart Elasticsearch
+
+- template: src=elasticsearch5.default.j2 dest=/etc/default/elasticsearch owner={{ elasticsearch_user }} group={{ elasticsearch_group }} mode=0644
+  when: elasticsearch_version is version_compare('5.0', '>=')
   notify: Restart Elasticsearch
 
 # Register Elasticsearch service to start on boot

--- a/templates/elasticsearch5.default.j2
+++ b/templates/elasticsearch5.default.j2
@@ -22,7 +22,7 @@ JAVA_HOME={{ elasticsearch_java_home }}
 {% endif %}
 
 # Elasticsearch configuration directory
-ES_PATH_CONF=/etc/elasticsearch
+ES_PATH_CONF={{ elasticsearch_conf_dir }}
 
 # Elasticsearch PID directory
 #PID_DIR=/var/run/elasticsearch

--- a/templates/elasticsearch5.yml.j2
+++ b/templates/elasticsearch5.yml.j2
@@ -1,0 +1,538 @@
+##################### ElasticSearch Configuration Example #####################
+
+# This file contains an overview of various configuration settings,
+# targeted at operations staff. Application developers should
+# consult the guide at <http://elasticsearch.org/guide>.
+#
+# The installation procedure is covered at
+# <http://elasticsearch.org/guide/reference/setup/installation.html>.
+#
+# ElasticSearch comes with reasonable defaults for most settings,
+# so you can try it out without bothering with configuration.
+#
+# Most of the time, these defaults are just fine for running a production
+# cluster. If you're fine-tuning your cluster, or wondering about the
+# effect of certain configuration option, please _do ask_ on the
+# mailing list or IRC channel [http://elasticsearch.org/community].
+
+# See <http://elasticsearch.org/guide/reference/setup/configuration.html>
+# for information on supported formats and syntax for the configuration file.
+
+
+################################### Cluster ###################################
+
+# Cluster name identifies your cluster for auto-discovery. If you're running
+# multiple clusters on the same network, make sure you're using unique names.
+#
+# cluster.name: elasticsearch
+{% if elasticsearch_cluster_name is defined %}
+cluster.name: {{ elasticsearch_cluster_name }}
+{% endif %}
+
+#################################### Node #####################################
+
+# Node names are generated dynamically on startup, so you're relieved
+# from configuring them manually. You can tie this node to a specific name:
+#
+# node.name: "Franz Kafka"
+{% if elasticsearch_node_name is defined %}
+node.name: {{ elasticsearch_node_name }}
+{% endif %}
+
+# Every node can be configured to allow or deny being eligible as the master,
+# and to allow or deny to store the data.
+#
+# Allow this node to be eligible as a master node (enabled by default):
+#
+# node.master: true
+{% if elasticsearch_node_master is defined %}
+node.master: {{ elasticsearch_node_master }}
+{% endif %}
+#
+# Allow this node to store data (enabled by default):
+#
+# node.data: true
+{% if elasticsearch_node_data is defined %}
+node.data: {{ elasticsearch_node_data }}
+{% endif %}
+
+# You can exploit these settings to design advanced cluster topologies.
+#
+# 1. You want this node to never become a master node, only to hold data.
+#    This will be the "workhorse" of your cluster.
+#
+# node.master: false
+# node.data: true
+#
+# 2. You want this node to only serve as a master: to not store any data and
+#    to have free resources. This will be the "coordinator" of your cluster.
+#
+# node.master: true
+# node.data: false
+#
+# 3. You want this node to be neither master nor data node, but
+#    to act as a "search load balancer" (fetching data from nodes,
+#    aggregating results, etc.)
+#
+# node.master: false
+# node.data: false
+
+# Use the Cluster Health API [http://localhost:9200/_cluster/health], the
+# Node Info API [http://localhost:9200/_cluster/nodes] or GUI tools
+# such as <http://github.com/lukas-vlcek/bigdesk> and
+# <http://mobz.github.com/elasticsearch-head> to inspect the cluster state.
+
+# A node can have generic attributes associated with it, which can later be used
+# for customized shard allocation filtering, or allocation awareness. An attribute
+# is a simple key value pair, similar to node.key: value, here is an example:
+#
+# node.rack: rack314
+{% if elasticsearch_node_rack is defined %}
+node.rack: {{ elasticsearch_node_rack }}
+{% endif %}
+
+# By default, multiple nodes are allowed to start from the same installation location
+# to disable it, set the following:
+# node.max_local_storage_nodes: 1
+{% if elasticsearch_node_max_local_storage_nodes is defined %}
+node.max_local_storage_nodes: {{ elasticsearch_node_max_local_storage_nodes }}
+{% endif %}
+
+# Disable network discovery by setting the following (useful for development):
+# node.local: true
+{% if elasticsearch_node_local is defined %}
+node.local: {{ elasticsearch_node_local }}
+{% endif %}
+
+#################################### Index ####################################
+
+# Since elasticsearch 5.x index level settings can NOT be set on the nodes 
+# configuration like the elasticsearch.yaml, in system properties or command line 
+# arguments.In order to upgrade all indices the settings must be updated via the 
+# /${index}/_settings API. Unless all settings are dynamic all indices must be closed 
+# in order to apply the upgradeIndices created in the future should use index templates 
+#to set default values. 
+
+#Please ensure all required values are updated on all indices by executing: 
+
+#curl -XPUT 'http://localhost:9200/_all/_settings?preserve_existing=true' -d '{
+#  "index.mapper_dynamic" : "true"
+#}'
+
+
+#################################### Paths ####################################
+{% if ESversionGt5 is not defined %}
+
+# Path to directory containing configuration (this file and logging.yml):
+# The path.conf variable is not usable on ES version >= 6.0.0
+# path.conf: /path/to/conf
+{% if elasticsearch_conf_dir is defined %}
+path.conf: {{ elasticsearch_conf_dir }}
+{% endif %}
+{% endif %}
+
+# Path to directory where to store index data allocated for this node.
+#
+# path.data: /path/to/data
+{% if elasticsearch_data_dir is defined %}
+path.data: {{ elasticsearch_data_dir }}
+{% endif %}
+
+# Can optionally include more than one location, causing data to be striped across
+# the locations (a la RAID 0) on a file level, favouring locations with most free
+# space on creation. For example:
+#
+# path.data: /path/to/data1,/path/to/data2
+
+# Path to log files:
+#
+# path.logs: /path/to/logs
+{% if elasticsearch_log_dir is defined %}
+path.logs: {{ elasticsearch_log_dir }}
+{% endif %}
+
+#################################### Plugin ###################################
+
+# If a plugin listed here is not installed for current node, the node will not start.
+#
+# plugin.mandatory: mapper-attachments,lang-groovy
+
+
+################################### Memory ####################################
+
+# ElasticSearch performs poorly when JVM starts swapping: you should ensure that
+# it _never_ swaps.
+#
+# Set this property to true to lock the memory:
+#
+#
+{% if elasticsearch_memory_bootstrap_mlockall is defined %}
+bootstrap.memory_lock: {{ elasticsearch_memory_bootstrap_mlockall }}
+{% endif %}
+
+# Make sure that the ES_MIN_MEM and ES_MAX_MEM environment variables are set
+# to the same value, and that the machine has enough memory to allocate
+# for ElasticSearch, leaving enough memory for the operating system itself.
+#
+# You should also make sure that the ElasticSearch process is allowed to lock
+# the memory, eg. by using `ulimit -l unlimited`.
+
+
+############################## Network And HTTP ###############################
+
+# ElasticSearch, by default, binds itself to the 0.0.0.0 address, and listens
+# on port [9200-9300] for HTTP traffic and on port [9300-9400] for node-to-node
+# communication. (the range means that if the port is busy, it will automatically
+# try the next port).
+
+# Set the bind address specifically (IPv4 or IPv6):
+#
+# network.bind_host: 192.168.0.1
+{% if elasticsearch_network_bind_host is defined %}
+network.bind_host: {{ elasticsearch_network_bind_host }}
+{% endif %}
+
+# Set the address other nodes will use to communicate with this node. If not
+# set, it is automatically derived. It must point to an actual IP address.
+#
+# network.publish_host: 192.168.0.1
+{% if elasticsearch_network_publish_host is defined %}
+network.publish_host: {{ elasticsearch_network_publish_host }}
+{% endif %}
+
+# Set both 'bind_host' and 'publish_host':
+#
+# network.host: 192.168.0.1
+{% if elasticsearch_network_host is defined %}
+network.host: {{ elasticsearch_network_host }}
+{% endif %}
+
+# Set a custom port for the node to node communication (9300 by default):
+#
+# transport.tcp.port: 9300
+{% if elasticsearch_network_transport_tcp_port is defined %}
+transport.tcp.port: {{ elasticsearch_network_transport_tcp_port }}
+{% endif %}
+
+# Enable compression for all communication between nodes (disabled by default):
+#
+# transport.tcp.compress: true
+{% if elasticsearch_network_transport_tcp_compress is defined %}
+transport.tcp.compress: {{ elasticsearch_network_transport_tcp_compress }}
+{% endif %}
+
+# Set a custom port to listen for HTTP traffic:
+#
+# http.port: 9200
+{% if elasticsearch_network_http_port is defined %}
+http.port: {{ elasticsearch_network_http_port }}
+{% endif %}
+
+# Set a custom allowed content length:
+#
+# http.max_content_length: 100mb
+{% if elasticsearch_network_http_max_content_lengtht is defined %}
+http.max_content_length: {{ elasticsearch_network_http_max_content_lengtht }}
+{% endif %}
+
+# Disable HTTP completely:
+#
+# http.enabled: false
+{% if elasticsearch_network_http_enabled is defined %}
+http.enabled: {{ elasticsearch_network_http_enabled }}
+{% endif %}
+
+################################### Gateway ###################################
+
+# The gateway allows for persisting the cluster state between full cluster
+# restarts. Every change to the state (such as adding an index) will be stored
+# in the gateway, and when the cluster starts up for the first time,
+# it will read its state from the gateway.
+
+# There are several types of gateway implementations. For more information,
+# see <http://elasticsearch.org/guide/reference/modules/gateway>.
+
+# The default gateway type is the "local" gateway (recommended):
+#
+# gateway.type: local
+{% if elasticsearch_gateway_type is defined %}
+gateway.type: {{ elasticsearch_gateway_type }}
+{% endif %}
+
+# Settings below control how and when to start the initial recovery process on
+# a full cluster restart (to reuse as much local data as possible when using shared
+# gateway).
+
+# Allow recovery process after N nodes in a cluster are up:
+#
+# gateway.recover_after_nodes: 1
+{% if elasticsearch_gateway_recover_after_nodes is defined %}
+gateway.recover_after_nodes: {{ elasticsearch_gateway_recover_after_nodes }}
+{% endif %}
+
+# Set the timeout to initiate the recovery process, once the N nodes
+# from previous setting are up (accepts time value):
+#
+# gateway.recover_after_time: 5m
+{% if elasticsearch_gateway_recover_after_time is defined %}
+gateway.recover_after_time: {{ elasticsearch_gateway_recover_after_time }}
+{% endif %}
+
+# Set how many nodes are expected in this cluster. Once these N nodes
+# are up (and recover_after_nodes is met), begin recovery process immediately
+# (without waiting for recover_after_time to expire):
+#
+# gateway.expected_nodes: 2
+{% if elasticsearch_gateway_expected_nodes is defined %}
+gateway.expected_nodes: {{ elasticsearch_gateway_expected_nodes }}
+{% endif %}
+
+############################# Recovery Throttling #############################
+
+# These settings allow to control the process of shards allocation between
+# nodes during initial recovery, replica allocation, rebalancing,
+# or when adding and removing nodes.
+
+# Set the number of concurrent recoveries happening on a node:
+#
+# 1. During the initial recovery
+#
+# cluster.routing.allocation.node_initial_primaries_recoveries: 4
+{% if elasticsearch_recovery_node_initial_primaries_recoveries is defined %}
+cluster.routing.allocation.node_initial_primaries_recoveries: {{ elasticsearch_recovery_node_initial_primaries_recoveries }}
+{% endif %}
+
+#
+# 2. During adding/removing nodes, rebalancing, etc
+#
+# cluster.routing.allocation.node_concurrent_recoveries: 2
+{% if elasticsearch_recovery_node_concurrent_recoveries is defined %}
+cluster.routing.allocation.node_concurrent_recoveries: {{ elasticsearch_recovery_node_concurrent_recoveries }}
+{% endif %}
+
+# Set to throttle throughput when recovering (eg. 100mb, by default unlimited):
+#
+# indices.recovery.max_size_per_sec: 0
+{% if elasticsearch_recovery_max_size_per_sec is defined %}
+indices.recovery.max_size_per_sec: {{ elasticsearch_recovery_max_size_per_sec }}
+{% endif %}
+
+# Set to limit the number of open concurrent streams when
+# recovering a shard from a peer:
+#
+# indices.recovery.concurrent_streams: 5
+{% if elasticsearch_recovery_concurrent_streams is defined %}
+indices.recovery.concurrent_streams: {{ elasticsearch_recovery_concurrent_streams }}
+{% endif %}
+
+
+################################## Discovery ##################################
+
+{% if elasticsearch_plugin_aws_version is defined %}
+
+discovery.type: ec2
+{% if elasticsearch_plugin_aws_ec2_groups is defined %}
+discovery.ec2.groups: '{{ elasticsearch_plugin_aws_ec2_groups }}'
+{% endif %}
+{% if elasticsearch_plugin_aws_ec2_ping_timeout is defined %}
+discovery.ec2.ping_timeout: {{ elasticsearch_plugin_aws_ec2_ping_timeout}}
+{% endif %}
+cloud.node.auto_attributes: true
+{% if elasticsearch_plugin_aws_access_key is defined %}
+{% if elasticsearch_plugin_aws_secret_key is defined %}
+cloud.aws.access_key: '{{ elasticsearch_plugin_aws_access_key }}'
+cloud.aws.secret_key: '{{ elasticsearch_plugin_aws_secret_key }}'
+{% endif %}
+{% endif %}
+{% if elasticsearch_plugin_aws_region is defined %}
+cloud.aws.region: {{ elasticsearch_plugin_aws_region}}
+{% endif %}
+
+{% endif %}
+
+# Discovery infrastructure ensures nodes can be found within a cluster
+# and master node is elected. Multicast discovery is the default.
+
+# Set to ensure a node sees N other master eligible nodes to be considered
+# operational within the cluster. Set this option to a higher value (2-4)
+# for large clusters (>3 nodes):
+#
+# discovery.zen.minimum_master_nodes: 1
+{% if elasticsearch_discovery_zen_minimum_master_nodes is defined %}
+discovery.zen.minimum_master_nodes: {{ elasticsearch_discovery_zen_minimum_master_nodes }}
+{% endif %}
+
+# Set the time to wait for ping responses from other nodes when discovering.
+# Set this option to a higher value on a slow or congested network
+# to minimize discovery failures:
+#
+# discovery.zen.ping.timeout: 3s
+{% if elasticsearch_discovery_zen_ping_timeout is defined %}
+discovery.zen.ping.timeout: {{ elasticsearch_discovery_zen_ping_timeout }}
+{% endif %}
+
+# See <http://elasticsearch.org/guide/reference/modules/discovery/zen.html>
+# for more information.
+
+# Unicast discovery allows to explicitly control which nodes will be used
+# to discover the cluster.
+#
+# Configure an initial list of master nodes in the cluster
+# to perform discovery when new nodes (master or data) are started:
+#
+# discovery.zen.ping.unicast.hosts: ["host1", "host2:port", "host3[portX-portY]"]
+{% if elasticsearch_discovery_zen_ping_unicast_hosts is defined %}
+discovery.zen.ping.unicast.hosts: {{ elasticsearch_discovery_zen_ping_unicast_hosts }}
+{% endif %}
+
+# EC2 discovery allows to use AWS EC2 API in order to perform discovery.
+#
+# You have to install the cloud-aws plugin for enabling the EC2 discovery.
+#
+# See <http://elasticsearch.org/guide/reference/modules/discovery/ec2.html>
+# for more information.
+#
+# See <http://elasticsearch.org/tutorials/2011/08/22/elasticsearch-on-ec2.html>
+# for a step-by-step tutorial.
+
+# Fault Discovery
+# See <http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-discovery-zen.html#fault-detection>
+{% if elasticsearch_discovery_zen_fd_ping_interval is defined %}
+discovery.zen.fd.ping_interval: {{ elasticsearch_discovery_zen_fd_ping_interval }}
+{% endif %}
+{% if elasticsearch_discovery_zen_fd_ping_timeout is defined %}
+discovery.zen.fd.ping_timeout: {{ elasticsearch_discovery_zen_fd_ping_timeout }}
+{% endif %}
+{% if elasticsearch_discovery_zen_fd_ping_retries is defined %}
+discovery.zen.fd.ping_retries: {{ elasticsearch_discovery_zen_fd_ping_retries }}
+{% endif %}
+
+
+################################## Slow Log ##################################
+
+# Shard level query and fetch threshold logging.
+
+#index.search.slowlog.threshold.query.warn: 10s
+{% if elasticsearch_slowlog_threshold_query_warn is defined %}
+index.search.slowlog.threshold.query.warn: {{ elasticsearch_slowlog_threshold_query_warn }}
+{% endif %}
+#index.search.slowlog.threshold.query.info: 5s
+{% if elasticsearch_slowlog_threshold_query_info is defined %}
+index.search.slowlog.threshold.query.info: {{ elasticsearch_slowlog_threshold_query_info }}
+{% endif %}
+#index.search.slowlog.threshold.query.debug: 2s
+{% if elasticsearch_slowlog_threshold_query_debug is defined %}
+index.search.slowlog.threshold.query.debug: {{ elasticsearch_slowlog_threshold_query_debug }}
+{% endif %}
+#index.search.slowlog.threshold.query.trace: 500ms
+{% if elasticsearch_slowlog_threshold_query_trace is defined %}
+index.search.slowlog.threshold.query.trace: {{ elasticsearch_slowlog_threshold_query_trace }}
+{% endif %}
+
+#index.search.slowlog.threshold.fetch.warn: 1s
+{% if elasticsearch_slowlog_threshold_fetch_warn is defined %}
+index.search.slowlog.threshold.fetch.warn: {{ elasticsearch_slowlog_threshold_fetch_warn }}
+{% endif %}
+#index.search.slowlog.threshold.fetch.info: 800ms
+{% if elasticsearch_slowlog_threshold_fetch_info is defined %}
+index.search.slowlog.threshold.fetch.info: {{ elasticsearch_slowlog_threshold_fetch_info }}
+{% endif %}
+#index.search.slowlog.threshold.fetch.debug: 500ms
+{% if elasticsearch_slowlog_threshold_fetch_debug is defined %}
+index.search.slowlog.threshold.fetch.debug: {{ elasticsearch_slowlog_threshold_fetch_debug }}
+{% endif %}
+#index.search.slowlog.threshold.fetch.trace: 200ms
+{% if elasticsearch_slowlog_threshold_fetch_trace is defined %}
+index.search.slowlog.threshold.fetch.trace: {{ elasticsearch_slowlog_threshold_fetch_trace }}
+{% endif %}
+
+#index.indexing.slowlog.threshold.index.warn: 10s
+{% if elasticsearch_slowlog_threshold_index_warn is defined %}
+index.indexing.slowlog.threshold.index.warn: {{ elasticsearch_slowlog_threshold_index_warn }}
+{% endif %}
+#index.indexing.slowlog.threshold.index.info: 5s
+{% if elasticsearch_slowlog_threshold_index_info is defined %}
+index.indexing.slowlog.threshold.index.info: {{ elasticsearch_slowlog_threshold_index_info }}
+{% endif %}
+#index.indexing.slowlog.threshold.index.debug: 2s
+{% if elasticsearch_slowlog_threshold_index_debug is defined %}
+index.indexing.slowlog.threshold.index.debug: {{ elasticsearch_slowlog_threshold_index_debug }}
+{% endif %}
+#index.indexing.slowlog.threshold.index.trace: 500ms
+{% if elasticsearch_slowlog_threshold_index_trace is defined %}
+index.indexing.slowlog.threshold.index.trace: {{ elasticsearch_slowlog_threshold_index_trace }}
+{% endif %}
+
+################################## GC Logging ################################
+
+#monitor.jvm.gc.ParNew.warn: 1000ms
+{% if elasticsearch_gc_par_new_warn is defined %}
+monitor.jvm.gc.ParNew.warn: {{ elasticsearch_gc_par_new_warn }}
+{% endif %}
+#monitor.jvm.gc.ParNew.info: 700ms
+{% if elasticsearch_gc_par_new_info is defined %}
+monitor.jvm.gc.ParNew.info: {{ elasticsearch_gc_par_new_info }}
+{% endif %}
+#monitor.jvm.gc.ParNew.debug: 400ms
+{% if elasticsearch_gc_par_new_debug is defined %}
+monitor.jvm.gc.ParNew.debug: {{ elasticsearch_gc_par_new_debug }}
+{% endif %}
+
+#monitor.jvm.gc.ConcurrentMarkSweep.warn: 10s
+{% if elasticsearch_gc_soncurrent_mark_sweep_warn is defined %}
+monitor.jvm.gc.ConcurrentMarkSweep.warn: {{ elasticsearch_gc_soncurrent_mark_sweep_warn }}
+{% endif %}
+#monitor.jvm.gc.ConcurrentMarkSweep.info: 5s
+{% if elasticsearch_gc_soncurrent_mark_sweep_info is defined %}
+monitor.jvm.gc.ConcurrentMarkSweep.info: {{ elasticsearch_gc_soncurrent_mark_sweep_info }}
+{% endif %}
+#monitor.jvm.gc.ConcurrentMarkSweep.debug: 2s
+{% if elasticsearch_gc_soncurrent_mark_sweep_debug is defined %}
+monitor.jvm.gc.ConcurrentMarkSweep.debug: {{ elasticsearch_gc_soncurrent_mark_sweep_debug }}
+{% endif %}
+
+################################### Varia #####################################
+
+{% if elasticsearch_plugin_marvel_version is defined %}
+
+{% if elasticsearch_plugin_marvel_agent_exporter_es_index_timeformat is defined %}
+marvel.agent.exporter.es.index.timeformat: {{ elasticsearch_plugin_marvel_agent_exporter_es_index_timeformat }}
+{% endif %}
+{% if elasticsearch_plugin_marvel_agent_interval is defined %}
+marvel.agent.interval: {{ elasticsearch_plugin_marvel_agent_interval }}
+{% endif %}
+{% if elasticsearch_plugin_marvel_agent_indices is defined %}
+marvel.agent.indices: {{ elasticsearch_plugin_marvel_agent_indices }}
+{% endif %}
+{% if elasticsearch_plugin_marvel_agent_exporter_es_hosts is defined %}
+marvel.agent.exporter.es.hosts: {{ elasticsearch_plugin_marvel_agent_exporter_es_hosts }}
+{% endif %}
+{% if elasticsearch_plugin_marvel_agent_enabled is defined %}
+marvel.agent.enabled: {{ elasticsearch_plugin_marvel_agent_enabled }}
+{% endif %}
+
+{% endif %}
+
+{% if elasticsearch_misc_auto_create_index is defined %}
+action.auto_create_index: {{ elasticsearch_misc_auto_create_index }}
+{% endif %}
+{% if elasticsearch_misc_disable_delete_all_indices is defined %}
+action.disable_delete_all_indices: {{ elasticsearch_misc_disable_delete_all_indices }}
+{% endif %}
+{% if elasticsearch_thread_pools is defined %}
+{% for threadPoolSetting in elasticsearch_thread_pools %}
+{{ threadPoolSetting }}
+{% endfor %}
+{% endif %}
+
+################################### Dynamic Scripting #####################################
+
+{% if elasticsearch_script_disable_dynamic is defined %}
+script.disable_dynamic: {{ elasticsearch_script_disable_dynamic }}
+{% endif %}
+
+################################### CORS Settings #####################################
+
+{% if elasticsearch_http_cors_enabled is defined %}
+http.cors.enabled: {{ elasticsearch_http_cors_enabled }}
+{% endif %}


### PR DESCRIPTION
This change includes the configuration changes described in issue #7 when using Elasticsearch version 5.0 or greater for files:

- /etc/default/elasticsearch
- /etc/elasticsearch/elasticsearch.ym

