### PR TITLE
Add Elasticsearch version 5 and 6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,11 +144,30 @@ elasticsearch_custom_jars:
 ### Configuring Thread Pools
 Elasticsearch [thread pools](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-threadpool.html) can be configured using the `elasticsearch_thread_pools` list variable:
 
+For Elasticsearch version < 5:
+
 ```
 elasticsearch_thread_pools:
   - "threadpool.bulk.type: fixed"
   - "threadpool.bulk.size: 50"
   - "threadpool.bulk.queue_size: 1000"
+```
+
+For Elasticsearch version 5, the above setting as changed a bit:
+
+```
+elasticsearch_thread_pools:
+  - "thread_pool.bulk.size: 2"
+  - "thread_pool.bulk.queue_size: 1000"
+```
+
+**Note: For Elasticsearch version greater than 5, The `bulk.size` limit is the number of cores + 1.**
+
+For Elasticsearch 6, the above setting is compatible, but will be removed in 7.0.0 (See https://www.elastic.co/guide/en/elasticsearch/reference/6.x/breaking-changes-6.3.html#_renaming_the_bulk_thread_pool). The `bulk` thread pool has been renamed to the `write` thread pool, and this is the equivalent settings:
+```
+elasticsearch_thread_pools:
+  - "thread_pool.write.size: 2"
+  - "thread_pool.write.queue_size: 1000"
 ```
 
 ### Enabling Sematext SPM

--- a/README_examples.md
+++ b/README_examples.md
@@ -1,0 +1,157 @@
+# Example vars settings for CentOS and Ubuntu
+This file shows the same config for CentOS and Ubuntu when using Elasticsearch version 1, 5 and 6.
+
+## Ubuntu and Elasticsearch version 1
+
+```
+# elasticsearch role
+
+elasticsearch_version: "1.7.6"
+elasticsearch_apt_java_package: "openjdk-8-jre-headless"
+elasticsearch_java_home: "/usr/lib/jvm/java-1.8.0-openjdk-amd64"
+elasticsearch_heap_size: "1g"
+elasticsearch_max_open_files: "65535"
+elasticsearch_timezone: "UTC"
+elasticsearch_node_max_local_storage_nodes: "1"
+elasticsearch_index_mapper_dynamic: "true"
+elasticsearch_memory_bootstrap_mlockall: "true"
+elasticsearch_install_java: "true"
+elasticsearch_thread_pools:
+  - "threadpool.bulk.type: fixed"
+  - "threadpool.bulk.size: 50"
+  - "threadpool.bulk.queue_size: 1000"
+elasticsearch_network_http_max_content_lengtht: 1024mb
+elasticsearch_plugins:
+  - { name: 'mobz/elasticsearch-head' }
+elasticsearch_discovery_zen_ping_multicast_enabled: "false"
+elasticsearch_max_locked_memory: "unlimited"
+elasticsearch_network_host: "127.0.0.1"
+```
+
+## Ubuntu and Elasticsearch version 5
+
+```
+# elasticsearch role
+
+elasticsearch_version: "5.6.10"
+elasticsearch_apt_java_package: "openjdk-8-jre-headless"
+elasticsearch_java_home: "/usr/lib/jvm/java-1.8.0-openjdk-amd64"
+elasticsearch_heap_size: "1g"
+elasticsearch_max_open_files: "65535"
+elasticsearch_timezone: "UTC"
+elasticsearch_node_max_local_storage_nodes: "1"
+elasticsearch_index_mapper_dynamic: "true"
+elasticsearch_memory_bootstrap_mlockall: "true"
+elasticsearch_install_java: "true"
+elasticsearch_thread_pools:
+  - "thread_pool.bulk.size: 2"
+  - "thread_pool.bulk.queue_size: 1000"
+elasticsearch_network_http_max_content_lengtht: 1024mb
+elasticsearch_plugins:
+  - { name: 'mobz/elasticsearch-head' }
+elasticsearch_discovery_zen_ping_multicast_enabled: "false"
+elasticsearch_max_locked_memory: "unlimited"
+elasticsearch_network_host: "127.0.0.1"
+```
+
+## Ubuntu and Elasticsearch version 6
+
+```
+# elasticsearch role
+
+elasticsearch_version: "6.5.4"
+elasticsearch_apt_java_package: "openjdk-8-jre-headless"
+elasticsearch_java_home: "/usr/lib/jvm/java-1.8.0-openjdk-amd64"
+elasticsearch_heap_size: "1g"
+elasticsearch_max_open_files: "65535"
+elasticsearch_timezone: "UTC"
+elasticsearch_node_max_local_storage_nodes: "1"
+elasticsearch_index_mapper_dynamic: "true"
+elasticsearch_memory_bootstrap_mlockall: "true"
+elasticsearch_install_java: "true"
+elasticsearch_thread_pools:
+  - "thread_pool.write.size: 2"
+  - "thread_pool.write.queue_size: 1000"
+elasticsearch_network_http_max_content_lengtht: 1024mb
+elasticsearch_plugins:
+  - { name: 'mobz/elasticsearch-head' }
+elasticsearch_discovery_zen_ping_multicast_enabled: "false"
+elasticsearch_max_locked_memory: "unlimited"
+elasticsearch_network_host: "127.0.0.1"
+```
+
+## CentOS and Elastisearch version 1
+
+```
+# elasticsearch role
+
+elasticsearch_version: "1.7.5"
+elasticsearch_java_home: "/usr/lib/jvm/jre-1.8.0"
+elasticsearch_heap_size: "1g"
+elasticsearch_max_open_files: "65535"
+elasticsearch_timezone: "UTC"
+elasticsearch_node_max_local_storage_nodes: "1"
+elasticsearch_index_mapper_dynamic: "true"
+elasticsearch_memory_bootstrap_mlockall: "true"
+elasticsearch_install_java: "true"
+elasticsearch_thread_pools:
+  - "threadpool.bulk.type: fixed"
+  - "threadpool.bulk.size: 50"
+  - "threadpool.bulk.queue_size: 1000"
+elasticsearch_network_http_max_content_lengtht: 1024mb
+elasticsearch_plugins:
+  - { name: 'mobz/elasticsearch-head' }
+elasticsearch_discovery_zen_ping_multicast_enabled: "false"
+elasticsearch_max_locked_memory: "unlimited"
+elasticsearch_network_host: "127.0.0.1"
+```
+
+## CentOS and Elastisearch version 5
+
+```
+# elasticsearch role
+
+elasticsearch_version: "5.6.10'"
+elasticsearch_java_home: "/usr/lib/jvm/jre-1.8.0"
+elasticsearch_heap_size: "1g"
+elasticsearch_max_open_files: "65535"
+elasticsearch_timezone: "UTC"
+elasticsearch_node_max_local_storage_nodes: "1"
+elasticsearch_index_mapper_dynamic: "true"
+elasticsearch_memory_bootstrap_mlockall: "true"
+elasticsearch_install_java: "true"
+elasticsearch_thread_pools:
+  - "thread_pool.bulk.size: 2"
+  - "thread_pool.bulk.queue_size: 1000"
+elasticsearch_network_http_max_content_lengtht: 1024mb
+elasticsearch_plugins:
+  - { name: 'mobz/elasticsearch-head' }
+elasticsearch_discovery_zen_ping_multicast_enabled: "false"
+elasticsearch_max_locked_memory: "unlimited"
+elasticsearch_network_host: "127.0.0.1"
+```
+
+## CentOS and Elastisearch version 6
+
+```
+# elasticsearch role
+
+elasticsearch_version: "6.5.4'"
+elasticsearch_java_home: "/usr/lib/jvm/jre-1.8.0"
+elasticsearch_heap_size: "1g"
+elasticsearch_max_open_files: "65535"
+elasticsearch_timezone: "UTC"
+elasticsearch_node_max_local_storage_nodes: "1"
+elasticsearch_index_mapper_dynamic: "true"
+elasticsearch_memory_bootstrap_mlockall: "true"
+elasticsearch_install_java: "true"
+elasticsearch_thread_pools:
+  - "thread_pool.bulk.size: 2"
+  - "thread_pool.bulk.queue_size: 1000"
+elasticsearch_network_http_max_content_lengtht: 1024mb
+elasticsearch_plugins:
+  - { name: 'mobz/elasticsearch-head' }
+elasticsearch_discovery_zen_ping_multicast_enabled: "false"
+elasticsearch_max_locked_memory: "unlimited"
+elasticsearch_network_host: "127.0.0.1"
+```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 
 elasticsearch_user: elasticsearch
 elasticsearch_group: elasticsearch
-elasticsearch_download_url: https://download.elasticsearch.org/elasticsearch/elasticsearch
+elasticsearch_download_url: https://artifacts.elastic.co/downloads/elasticsearch
 elasticsearch_version: 1.7.6
 elasticsearch_apt_repos: []
 elasticsearch_apt_java_package: default-jre-headless
@@ -22,6 +22,10 @@ elasticsearch_service_startonboot: yes
 #elasticsearch_http_cors_enabled: "false"
 elasticsearch_service_state: started
 elasticsearch_network_bind_host: "127.0.0.1"
+
+# Elasticsearch 1.7 Ansible Variables
+
+elasticsearch17_download_url: https://download.elasticsearch.org/elasticsearch/elasticsearch
 
 # Non-Elasticsearch Defaults
 apt_cache_valid_time: 300 # seconds between "apt-get update" calls.

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,5 +1,20 @@
 ---
 # Elasticsearch debian install
+
+# Get elasticsearch version when elasticsearch is already installed
+- name: Get installed elasticsearch version
+  shell: dpkg-query -f='${Version}' -W 'elasticsearch'
+  register: installed_elasticsearch_version
+  ignore_errors: yes
+
+- name: Abort when elasticsearch installed version < 1.8 and version >=5 is going to be installed
+  fail:
+    msg: "Please uninstall elasticsearch {{ installed_elasticsearch_version.stdout }} before upgrading to {{ elasticsearch_version }} version"
+  when:
+    - installed_elasticsearch_version is succeeded
+    - installed_elasticsearch_version.stdout is version_compare('1.8', '<')
+    - elasticsearch_version is version_compare('5.0', '>=')
+
 # Update repos
 - name: Install python-software-properties
   apt:

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -43,12 +43,17 @@
 # Check whether we have aleady installed the same version
 - shell: if [ -e /usr/share/elasticsearch/lib/elasticsearch-{{ elasticsearch_version }}.jar ]; then echo yes; else echo no; fi;
   register: version_exists
-  always_run: True
+  check_mode: no
 
-# Download deb if needed
-- name: Download Elasticsearch deb
+# Download deb if needed (ES version < 5.0.0)
+- name: Download Elasticsearch deb (ES version < 5.0.0)
+  get_url: url={{ elasticsearch17_download_url }}/elasticsearch-{{ elasticsearch_version }}.deb dest=/tmp/elasticsearch-{{ elasticsearch_version }}.deb mode=0440
+  when: version_exists.stdout == 'no' and elasticsearch_version is version_compare('5.0', '<')
+
+# Download deb if needed (ES version >= 5.0.0)
+- name: Download Elasticsearch deb (ES version >= 5.0.0)
   get_url: url={{ elasticsearch_download_url }}/elasticsearch-{{ elasticsearch_version }}.deb dest=/tmp/elasticsearch-{{ elasticsearch_version }}.deb mode=0440
-  when: version_exists.stdout == 'no'
+  when: version_exists.stdout == 'no' and elasticsearch_version is version_compare('5.0', '>=')
 
 # Uninstall previous version if applicable
 - name: Uninstalling previous version if applicable

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -11,7 +11,7 @@
     option: enabled
     value: 1
 
-- name: "Add elasticsearch repo"
+- name: "Add elasticsearch 1.7.x repo"
   yum_repository:
     name: "elasticsearch-1.7"
     description: "Elasticsearch repository for 1.7.x packages"
@@ -19,6 +19,27 @@
     gpgkey: "http://packages.elastic.co/GPG-KEY-elasticsearch"
     gpgcheck: yes
     baseurl: "http://packages.elastic.co/elasticsearch/1.7/centos"
+  when: elasticsearch_version is version_compare('5.0', '<')
+
+- name: "Add elasticsearch 5.x repo"
+  yum_repository:
+    name: "elasticsearch-5.x"
+    description: "Elasticsearch repository for 5.x packages"
+    file: elasticsearch_repo
+    gpgkey: "https://artifacts.elastic.co/GPG-KEY-elasticsearch"
+    gpgcheck: yes
+    baseurl: "https://artifacts.elastic.co/packages/5.x/yum"
+  when: elasticsearch_version is version_compare('5.0', '>=') and elasticsearch_version is version_compare('6.0', '<')
+
+- name: "Add elasticsearch 6.x repo"
+  yum_repository:
+    name: "elasticsearch-6.x"
+    description: "Elasticsearch repository for 6.x packages"
+    file: elasticsearch_repo
+    gpgkey: "https://artifacts.elastic.co/GPG-KEY-elasticsearch"
+    gpgcheck: yes
+    baseurl: "https://artifacts.elastic.co/packages/6.x/yum"
+  when: elasticsearch_version is version_compare('6.0', '>=')
 
 - name: "Install services "
   yum:
@@ -26,5 +47,4 @@
     state: "installed"
   with_items:
     - java-1.8.0-openjdk
-    - elasticsearch
-
+    - "elasticsearch-{{ elasticsearch_version }}"

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,4 +1,21 @@
 ---
+# Elasticsearch CentOS/RedHat install
+
+# Get elasticsearch version when elasticsearch is already installed
+- name: Get installed elasticsearch version
+  shell: rpm -qa --queryformat '%{version}' elasticsearch
+  args:
+    warn: false
+  register: installed_elasticsearch_version
+
+- name: Abort when elasticsearch installed version < 1.8 and version >=5 is going to be installed
+  fail:
+    msg: "Please uninstall elasticsearch {{ installed_elasticsearch_version.stdout }} before upgrading to {{ elasticsearch_version }} version"
+  when:
+    - installed_elasticsearch_version.stdout|trim != ""
+    - installed_elasticsearch_version.stdout is version_compare('1.8', '<')
+    - elasticsearch_version is version_compare('5.0', '>=')
+
 - name: "Install epel repo"
   yum:
     name: "epel-release"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,12 @@
 - name: "Elasticsearch OS dependant packages"
   include: "{{ ansible_os_family }}.yml"
 
+# Define auxiliar variable for ES version >= 6.0.0
+- name: Define ESversionGt5 variable when ES version >= 6.0.0
+  set_fact:
+    ESversionGt5: true
+  when: elasticsearch_version is version_compare('6.0', '>=')
+
 # Configure directories
 - name: Configuring directories
   file: path={{ elasticsearch_log_dir }} state=directory owner={{ elasticsearch_user }} group={{ elasticsearch_group }} recurse=yes
@@ -57,18 +63,63 @@
 - include: marvel.yml
   when: (elasticsearch_plugin_marvel_version is defined)
 
-# Configure Elasticsearch Node
-- name: Configuring Elasticsearch Node
-  template: src=elasticsearch.yml.j2 dest={{ elasticsearch_conf_dir }}/elasticsearch.yml owner={{ elasticsearch_user }} group={{ elasticsearch_group }} mode=0644
-  when: elasticsearch_conf_dir is defined
-  notify: Restart Elasticsearch
-- template: src=elasticsearch.default.j2 dest=/etc/default/elasticsearch owner={{ elasticsearch_user }} group={{ elasticsearch_group }} mode=0644
-  when: ansible_os_family == "Debian"
-  notify: Restart Elasticsearch
-- template: src=elasticsearch.default.j2 dest=/etc/sysconfig/elasticsearch owner={{ elasticsearch_user }} group={{ elasticsearch_group }} mode=0644
-  when: ansible_os_family == "RedHat"
-  notify: Restart Elasticsearch
+# Configure Elasticsearch Node (ES version < 5.0)
+- block:
+  - name: Configuring Elasticsearch Node (ES version < 5.0)
+    template:
+      src: elasticsearch.yml.j2
+      dest: "{{ elasticsearch_conf_dir }}/elasticsearch.yml "
+      owner: "{{ elasticsearch_user }}"
+      group: "{{ elasticsearch_group }}"
+      mode: 0644
+    when: elasticsearch_conf_dir is defined
+    notify: Restart Elasticsearch
+  - template:
+      src: elasticsearch.default.j2
+      dest: /etc/default/elasticsearch
+      owner: "{{ elasticsearch_user }}"
+      group: "{{ elasticsearch_group }}"
+      mode: 0644
+    when: ansible_os_family == "Debian"
+    notify: Restart Elasticsearch
+  - template:
+      src: elasticsearch.default.j2
+      dest: /etc/sysconfig/elasticsearch
+      owner: "{{ elasticsearch_user }}"
+      group: "{{ elasticsearch_group }}"
+      mode: 0644
+    when: ansible_os_family == "RedHat"
+    notify: Restart Elasticsearch
+  when: elasticsearch_version is version_compare('5.0', '<')
 
+# Configure Elasticsearch Node (ES version > 5.0)
+- block:
+  - name: Configuring Elasticsearch Node (ES version > 5.0
+    template:
+      src: elasticsearch5.yml.j2
+      dest: "{{ elasticsearch_conf_dir }}/elasticsearch.yml"
+      owner: "{{ elasticsearch_user }}"
+      group: "{{ elasticsearch_group }}"
+      mode: 0644
+    when: elasticsearch_conf_dir is defined
+    notify: Restart Elasticsearch
+  - template:
+      src: elasticsearch5.default.j2
+      dest: /etc/default/elasticsearch
+      owner: "{{ elasticsearch_user }}"
+      group: "{{ elasticsearch_group }}"
+      mode: 0644
+    when: ansible_os_family == "Debian"
+    notify: Restart Elasticsearch
+  - template:
+      src: elasticsearch5.default.j2
+      dest: /etc/sysconfig/elasticsearch
+      owner: "{{ elasticsearch_user }}"
+      group: "{{ elasticsearch_group }}"
+      mode: 0644
+    when: ansible_os_family == "RedHat"
+    notify: Restart Elasticsearch
+  when: elasticsearch_version is version_compare('5.0', '>=')
 
 # Register Elasticsearch service to start on boot
 - name: Ensure Elasticsearch is started on boot

--- a/templates/elasticsearch5.default.j2
+++ b/templates/elasticsearch5.default.j2
@@ -1,0 +1,85 @@
+################################
+# Elasticsearch
+################################
+{% if ESversionGt5 is not defined %}
+
+# Run ElasticSearch as this user ID and group ID
+#ES_USER=elasticsearch
+{% if elasticsearch_user is defined %}
+ES_USER={{ elasticsearch_user }}
+{% endif %}
+#ES_GROUP=elasticsearch
+{% if elasticsearch_group is defined %}
+ES_GROUP={{ elasticsearch_group }}
+{% endif %}
+{% endif %}
+
+# Elasticsearch home directory
+#ES_HOME=/usr/share/elasticsearch
+
+# Elasticsearch Java path
+#JAVA_HOME=
+{% if elasticsearch_java_home is defined %}
+JAVA_HOME={{ elasticsearch_java_home }}
+{% endif %}
+
+# Elasticsearch configuration directory
+ES_PATH_CONF={{ elasticsearch_conf_dir }}
+
+# Elasticsearch PID directory
+#PID_DIR=/var/run/elasticsearch
+
+# Additional Java OPTS
+#ES_JAVA_OPTS=
+{% if elasticsearch_heap_size is defined and elasticsearch_java_opts is defined %}
+ES_JAVA_OPTS="-Xms{{ elasticsearch_heap_size }} -Xmx{{ elasticsearch_heap_size }} {{ elasticsearch_java_opts }}"
+{% elif elasticsearch_heap_size is defined %}
+ES_JAVA_OPTS="-Xms{{ elasticsearch_heap_size }} -Xmx{{ elasticsearch_heap_size }}"
+{% elif elasticsearch_java_opts is defined %}
+ES_JAVA_OPTS="{{ elasticsearch_java_opts }}"
+{% endif %}
+
+# Configure restart on package upgrade (true, every other setting will lead to not restarting)
+#RESTART_ON_UPGRADE=true
+
+################################
+# Elasticsearch service
+################################
+
+# SysV init.d
+#
+# The number of seconds to wait before checking if Elasticsearch started successfully as a daemon process
+ES_STARTUP_SLEEP_TIME=5
+
+################################
+# System properties
+################################
+
+# Specifies the maximum file descriptor number that can be opened by this process
+# When using Systemd, this setting is ignored and the LimitNOFILE defined in
+# /usr/lib/systemd/system/elasticsearch.service takes precedence
+#MAX_OPEN_FILES=65536
+{% if elasticsearch_max_open_files is defined %}
+MAX_OPEN_FILES={{ elasticsearch_max_open_files }}
+{% endif %}
+
+# The maximum number of bytes of memory that may be locked into RAM
+# Set to "unlimited" if you use the 'bootstrap.memory_lock: true' option
+# in elasticsearch.yml.
+# When using systemd, LimitMEMLOCK must be set in a unit file such as
+# /etc/systemd/system/elasticsearch.service.d/override.conf.
+#MAX_LOCKED_MEMORY=unlimited
+{% if elasticsearch_max_locked_memory is defined %}
+MAX_LOCKED_MEMORY={{ elasticsearch_max_locked_memory }}
+{% endif %}
+
+# Maximum number of VMA (Virtual Memory Areas) a process can own
+# When using Systemd, this setting is ignored and the 'vm.max_map_count'
+# property is set at boot time in /usr/lib/sysctl.d/elasticsearch.conf
+#MAX_MAP_COUNT=262144
+
+# Environment Vars
+{% if elasticsearch_env_use_gc_logging is defined %}
+export ES_USE_GC_LOGGING=true
+{% endif %}
+

--- a/templates/elasticsearch5.yml.j2
+++ b/templates/elasticsearch5.yml.j2
@@ -1,0 +1,538 @@
+##################### ElasticSearch Configuration Example #####################
+
+# This file contains an overview of various configuration settings,
+# targeted at operations staff. Application developers should
+# consult the guide at <http://elasticsearch.org/guide>.
+#
+# The installation procedure is covered at
+# <http://elasticsearch.org/guide/reference/setup/installation.html>.
+#
+# ElasticSearch comes with reasonable defaults for most settings,
+# so you can try it out without bothering with configuration.
+#
+# Most of the time, these defaults are just fine for running a production
+# cluster. If you're fine-tuning your cluster, or wondering about the
+# effect of certain configuration option, please _do ask_ on the
+# mailing list or IRC channel [http://elasticsearch.org/community].
+
+# See <http://elasticsearch.org/guide/reference/setup/configuration.html>
+# for information on supported formats and syntax for the configuration file.
+
+
+################################### Cluster ###################################
+
+# Cluster name identifies your cluster for auto-discovery. If you're running
+# multiple clusters on the same network, make sure you're using unique names.
+#
+# cluster.name: elasticsearch
+{% if elasticsearch_cluster_name is defined %}
+cluster.name: {{ elasticsearch_cluster_name }}
+{% endif %}
+
+#################################### Node #####################################
+
+# Node names are generated dynamically on startup, so you're relieved
+# from configuring them manually. You can tie this node to a specific name:
+#
+# node.name: "Franz Kafka"
+{% if elasticsearch_node_name is defined %}
+node.name: {{ elasticsearch_node_name }}
+{% endif %}
+
+# Every node can be configured to allow or deny being eligible as the master,
+# and to allow or deny to store the data.
+#
+# Allow this node to be eligible as a master node (enabled by default):
+#
+# node.master: true
+{% if elasticsearch_node_master is defined %}
+node.master: {{ elasticsearch_node_master }}
+{% endif %}
+#
+# Allow this node to store data (enabled by default):
+#
+# node.data: true
+{% if elasticsearch_node_data is defined %}
+node.data: {{ elasticsearch_node_data }}
+{% endif %}
+
+# You can exploit these settings to design advanced cluster topologies.
+#
+# 1. You want this node to never become a master node, only to hold data.
+#    This will be the "workhorse" of your cluster.
+#
+# node.master: false
+# node.data: true
+#
+# 2. You want this node to only serve as a master: to not store any data and
+#    to have free resources. This will be the "coordinator" of your cluster.
+#
+# node.master: true
+# node.data: false
+#
+# 3. You want this node to be neither master nor data node, but
+#    to act as a "search load balancer" (fetching data from nodes,
+#    aggregating results, etc.)
+#
+# node.master: false
+# node.data: false
+
+# Use the Cluster Health API [http://localhost:9200/_cluster/health], the
+# Node Info API [http://localhost:9200/_cluster/nodes] or GUI tools
+# such as <http://github.com/lukas-vlcek/bigdesk> and
+# <http://mobz.github.com/elasticsearch-head> to inspect the cluster state.
+
+# A node can have generic attributes associated with it, which can later be used
+# for customized shard allocation filtering, or allocation awareness. An attribute
+# is a simple key value pair, similar to node.key: value, here is an example:
+#
+# node.rack: rack314
+{% if elasticsearch_node_rack is defined %}
+node.rack: {{ elasticsearch_node_rack }}
+{% endif %}
+
+# By default, multiple nodes are allowed to start from the same installation location
+# to disable it, set the following:
+# node.max_local_storage_nodes: 1
+{% if elasticsearch_node_max_local_storage_nodes is defined %}
+node.max_local_storage_nodes: {{ elasticsearch_node_max_local_storage_nodes }}
+{% endif %}
+
+# Disable network discovery by setting the following (useful for development):
+# node.local: true
+{% if elasticsearch_node_local is defined %}
+node.local: {{ elasticsearch_node_local }}
+{% endif %}
+
+#################################### Index ####################################
+
+# Since elasticsearch 5.x index level settings can NOT be set on the nodes 
+# configuration like the elasticsearch.yaml, in system properties or command line 
+# arguments.In order to upgrade all indices the settings must be updated via the 
+# /${index}/_settings API. Unless all settings are dynamic all indices must be closed 
+# in order to apply the upgradeIndices created in the future should use index templates 
+#to set default values. 
+
+#Please ensure all required values are updated on all indices by executing: 
+
+#curl -XPUT 'http://localhost:9200/_all/_settings?preserve_existing=true' -d '{
+#  "index.mapper_dynamic" : "true"
+#}'
+
+
+#################################### Paths ####################################
+{% if ESversionGt5 is not defined %}
+
+# Path to directory containing configuration (this file and logging.yml):
+# The path.conf variable is not usable on ES version >= 6.0.0
+# path.conf: /path/to/conf
+{% if elasticsearch_conf_dir is defined %}
+path.conf: {{ elasticsearch_conf_dir }}
+{% endif %}
+{% endif %}
+
+# Path to directory where to store index data allocated for this node.
+#
+# path.data: /path/to/data
+{% if elasticsearch_data_dir is defined %}
+path.data: {{ elasticsearch_data_dir }}
+{% endif %}
+
+# Can optionally include more than one location, causing data to be striped across
+# the locations (a la RAID 0) on a file level, favouring locations with most free
+# space on creation. For example:
+#
+# path.data: /path/to/data1,/path/to/data2
+
+# Path to log files:
+#
+# path.logs: /path/to/logs
+{% if elasticsearch_log_dir is defined %}
+path.logs: {{ elasticsearch_log_dir }}
+{% endif %}
+
+#################################### Plugin ###################################
+
+# If a plugin listed here is not installed for current node, the node will not start.
+#
+# plugin.mandatory: mapper-attachments,lang-groovy
+
+
+################################### Memory ####################################
+
+# ElasticSearch performs poorly when JVM starts swapping: you should ensure that
+# it _never_ swaps.
+#
+# Set this property to true to lock the memory:
+#
+#
+{% if elasticsearch_memory_bootstrap_mlockall is defined %}
+bootstrap.memory_lock: {{ elasticsearch_memory_bootstrap_mlockall }}
+{% endif %}
+
+# Make sure that the ES_MIN_MEM and ES_MAX_MEM environment variables are set
+# to the same value, and that the machine has enough memory to allocate
+# for ElasticSearch, leaving enough memory for the operating system itself.
+#
+# You should also make sure that the ElasticSearch process is allowed to lock
+# the memory, eg. by using `ulimit -l unlimited`.
+
+
+############################## Network And HTTP ###############################
+
+# ElasticSearch, by default, binds itself to the 0.0.0.0 address, and listens
+# on port [9200-9300] for HTTP traffic and on port [9300-9400] for node-to-node
+# communication. (the range means that if the port is busy, it will automatically
+# try the next port).
+
+# Set the bind address specifically (IPv4 or IPv6):
+#
+# network.bind_host: 192.168.0.1
+{% if elasticsearch_network_bind_host is defined %}
+network.bind_host: {{ elasticsearch_network_bind_host }}
+{% endif %}
+
+# Set the address other nodes will use to communicate with this node. If not
+# set, it is automatically derived. It must point to an actual IP address.
+#
+# network.publish_host: 192.168.0.1
+{% if elasticsearch_network_publish_host is defined %}
+network.publish_host: {{ elasticsearch_network_publish_host }}
+{% endif %}
+
+# Set both 'bind_host' and 'publish_host':
+#
+# network.host: 192.168.0.1
+{% if elasticsearch_network_host is defined %}
+network.host: {{ elasticsearch_network_host }}
+{% endif %}
+
+# Set a custom port for the node to node communication (9300 by default):
+#
+# transport.tcp.port: 9300
+{% if elasticsearch_network_transport_tcp_port is defined %}
+transport.tcp.port: {{ elasticsearch_network_transport_tcp_port }}
+{% endif %}
+
+# Enable compression for all communication between nodes (disabled by default):
+#
+# transport.tcp.compress: true
+{% if elasticsearch_network_transport_tcp_compress is defined %}
+transport.tcp.compress: {{ elasticsearch_network_transport_tcp_compress }}
+{% endif %}
+
+# Set a custom port to listen for HTTP traffic:
+#
+# http.port: 9200
+{% if elasticsearch_network_http_port is defined %}
+http.port: {{ elasticsearch_network_http_port }}
+{% endif %}
+
+# Set a custom allowed content length:
+#
+# http.max_content_length: 100mb
+{% if elasticsearch_network_http_max_content_lengtht is defined %}
+http.max_content_length: {{ elasticsearch_network_http_max_content_lengtht }}
+{% endif %}
+
+# Disable HTTP completely:
+#
+# http.enabled: false
+{% if elasticsearch_network_http_enabled is defined %}
+http.enabled: {{ elasticsearch_network_http_enabled }}
+{% endif %}
+
+################################### Gateway ###################################
+
+# The gateway allows for persisting the cluster state between full cluster
+# restarts. Every change to the state (such as adding an index) will be stored
+# in the gateway, and when the cluster starts up for the first time,
+# it will read its state from the gateway.
+
+# There are several types of gateway implementations. For more information,
+# see <http://elasticsearch.org/guide/reference/modules/gateway>.
+
+# The default gateway type is the "local" gateway (recommended):
+#
+# gateway.type: local
+{% if elasticsearch_gateway_type is defined %}
+gateway.type: {{ elasticsearch_gateway_type }}
+{% endif %}
+
+# Settings below control how and when to start the initial recovery process on
+# a full cluster restart (to reuse as much local data as possible when using shared
+# gateway).
+
+# Allow recovery process after N nodes in a cluster are up:
+#
+# gateway.recover_after_nodes: 1
+{% if elasticsearch_gateway_recover_after_nodes is defined %}
+gateway.recover_after_nodes: {{ elasticsearch_gateway_recover_after_nodes }}
+{% endif %}
+
+# Set the timeout to initiate the recovery process, once the N nodes
+# from previous setting are up (accepts time value):
+#
+# gateway.recover_after_time: 5m
+{% if elasticsearch_gateway_recover_after_time is defined %}
+gateway.recover_after_time: {{ elasticsearch_gateway_recover_after_time }}
+{% endif %}
+
+# Set how many nodes are expected in this cluster. Once these N nodes
+# are up (and recover_after_nodes is met), begin recovery process immediately
+# (without waiting for recover_after_time to expire):
+#
+# gateway.expected_nodes: 2
+{% if elasticsearch_gateway_expected_nodes is defined %}
+gateway.expected_nodes: {{ elasticsearch_gateway_expected_nodes }}
+{% endif %}
+
+############################# Recovery Throttling #############################
+
+# These settings allow to control the process of shards allocation between
+# nodes during initial recovery, replica allocation, rebalancing,
+# or when adding and removing nodes.
+
+# Set the number of concurrent recoveries happening on a node:
+#
+# 1. During the initial recovery
+#
+# cluster.routing.allocation.node_initial_primaries_recoveries: 4
+{% if elasticsearch_recovery_node_initial_primaries_recoveries is defined %}
+cluster.routing.allocation.node_initial_primaries_recoveries: {{ elasticsearch_recovery_node_initial_primaries_recoveries }}
+{% endif %}
+
+#
+# 2. During adding/removing nodes, rebalancing, etc
+#
+# cluster.routing.allocation.node_concurrent_recoveries: 2
+{% if elasticsearch_recovery_node_concurrent_recoveries is defined %}
+cluster.routing.allocation.node_concurrent_recoveries: {{ elasticsearch_recovery_node_concurrent_recoveries }}
+{% endif %}
+
+# Set to throttle throughput when recovering (eg. 100mb, by default unlimited):
+#
+# indices.recovery.max_size_per_sec: 0
+{% if elasticsearch_recovery_max_size_per_sec is defined %}
+indices.recovery.max_size_per_sec: {{ elasticsearch_recovery_max_size_per_sec }}
+{% endif %}
+
+# Set to limit the number of open concurrent streams when
+# recovering a shard from a peer:
+#
+# indices.recovery.concurrent_streams: 5
+{% if elasticsearch_recovery_concurrent_streams is defined %}
+indices.recovery.concurrent_streams: {{ elasticsearch_recovery_concurrent_streams }}
+{% endif %}
+
+
+################################## Discovery ##################################
+
+{% if elasticsearch_plugin_aws_version is defined %}
+
+discovery.type: ec2
+{% if elasticsearch_plugin_aws_ec2_groups is defined %}
+discovery.ec2.groups: '{{ elasticsearch_plugin_aws_ec2_groups }}'
+{% endif %}
+{% if elasticsearch_plugin_aws_ec2_ping_timeout is defined %}
+discovery.ec2.ping_timeout: {{ elasticsearch_plugin_aws_ec2_ping_timeout}}
+{% endif %}
+cloud.node.auto_attributes: true
+{% if elasticsearch_plugin_aws_access_key is defined %}
+{% if elasticsearch_plugin_aws_secret_key is defined %}
+cloud.aws.access_key: '{{ elasticsearch_plugin_aws_access_key }}'
+cloud.aws.secret_key: '{{ elasticsearch_plugin_aws_secret_key }}'
+{% endif %}
+{% endif %}
+{% if elasticsearch_plugin_aws_region is defined %}
+cloud.aws.region: {{ elasticsearch_plugin_aws_region}}
+{% endif %}
+
+{% endif %}
+
+# Discovery infrastructure ensures nodes can be found within a cluster
+# and master node is elected. Multicast discovery is the default.
+
+# Set to ensure a node sees N other master eligible nodes to be considered
+# operational within the cluster. Set this option to a higher value (2-4)
+# for large clusters (>3 nodes):
+#
+# discovery.zen.minimum_master_nodes: 1
+{% if elasticsearch_discovery_zen_minimum_master_nodes is defined %}
+discovery.zen.minimum_master_nodes: {{ elasticsearch_discovery_zen_minimum_master_nodes }}
+{% endif %}
+
+# Set the time to wait for ping responses from other nodes when discovering.
+# Set this option to a higher value on a slow or congested network
+# to minimize discovery failures:
+#
+# discovery.zen.ping.timeout: 3s
+{% if elasticsearch_discovery_zen_ping_timeout is defined %}
+discovery.zen.ping.timeout: {{ elasticsearch_discovery_zen_ping_timeout }}
+{% endif %}
+
+# See <http://elasticsearch.org/guide/reference/modules/discovery/zen.html>
+# for more information.
+
+# Unicast discovery allows to explicitly control which nodes will be used
+# to discover the cluster.
+#
+# Configure an initial list of master nodes in the cluster
+# to perform discovery when new nodes (master or data) are started:
+#
+# discovery.zen.ping.unicast.hosts: ["host1", "host2:port", "host3[portX-portY]"]
+{% if elasticsearch_discovery_zen_ping_unicast_hosts is defined %}
+discovery.zen.ping.unicast.hosts: {{ elasticsearch_discovery_zen_ping_unicast_hosts }}
+{% endif %}
+
+# EC2 discovery allows to use AWS EC2 API in order to perform discovery.
+#
+# You have to install the cloud-aws plugin for enabling the EC2 discovery.
+#
+# See <http://elasticsearch.org/guide/reference/modules/discovery/ec2.html>
+# for more information.
+#
+# See <http://elasticsearch.org/tutorials/2011/08/22/elasticsearch-on-ec2.html>
+# for a step-by-step tutorial.
+
+# Fault Discovery
+# See <http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-discovery-zen.html#fault-detection>
+{% if elasticsearch_discovery_zen_fd_ping_interval is defined %}
+discovery.zen.fd.ping_interval: {{ elasticsearch_discovery_zen_fd_ping_interval }}
+{% endif %}
+{% if elasticsearch_discovery_zen_fd_ping_timeout is defined %}
+discovery.zen.fd.ping_timeout: {{ elasticsearch_discovery_zen_fd_ping_timeout }}
+{% endif %}
+{% if elasticsearch_discovery_zen_fd_ping_retries is defined %}
+discovery.zen.fd.ping_retries: {{ elasticsearch_discovery_zen_fd_ping_retries }}
+{% endif %}
+
+
+################################## Slow Log ##################################
+
+# Shard level query and fetch threshold logging.
+
+#index.search.slowlog.threshold.query.warn: 10s
+{% if elasticsearch_slowlog_threshold_query_warn is defined %}
+index.search.slowlog.threshold.query.warn: {{ elasticsearch_slowlog_threshold_query_warn }}
+{% endif %}
+#index.search.slowlog.threshold.query.info: 5s
+{% if elasticsearch_slowlog_threshold_query_info is defined %}
+index.search.slowlog.threshold.query.info: {{ elasticsearch_slowlog_threshold_query_info }}
+{% endif %}
+#index.search.slowlog.threshold.query.debug: 2s
+{% if elasticsearch_slowlog_threshold_query_debug is defined %}
+index.search.slowlog.threshold.query.debug: {{ elasticsearch_slowlog_threshold_query_debug }}
+{% endif %}
+#index.search.slowlog.threshold.query.trace: 500ms
+{% if elasticsearch_slowlog_threshold_query_trace is defined %}
+index.search.slowlog.threshold.query.trace: {{ elasticsearch_slowlog_threshold_query_trace }}
+{% endif %}
+
+#index.search.slowlog.threshold.fetch.warn: 1s
+{% if elasticsearch_slowlog_threshold_fetch_warn is defined %}
+index.search.slowlog.threshold.fetch.warn: {{ elasticsearch_slowlog_threshold_fetch_warn }}
+{% endif %}
+#index.search.slowlog.threshold.fetch.info: 800ms
+{% if elasticsearch_slowlog_threshold_fetch_info is defined %}
+index.search.slowlog.threshold.fetch.info: {{ elasticsearch_slowlog_threshold_fetch_info }}
+{% endif %}
+#index.search.slowlog.threshold.fetch.debug: 500ms
+{% if elasticsearch_slowlog_threshold_fetch_debug is defined %}
+index.search.slowlog.threshold.fetch.debug: {{ elasticsearch_slowlog_threshold_fetch_debug }}
+{% endif %}
+#index.search.slowlog.threshold.fetch.trace: 200ms
+{% if elasticsearch_slowlog_threshold_fetch_trace is defined %}
+index.search.slowlog.threshold.fetch.trace: {{ elasticsearch_slowlog_threshold_fetch_trace }}
+{% endif %}
+
+#index.indexing.slowlog.threshold.index.warn: 10s
+{% if elasticsearch_slowlog_threshold_index_warn is defined %}
+index.indexing.slowlog.threshold.index.warn: {{ elasticsearch_slowlog_threshold_index_warn }}
+{% endif %}
+#index.indexing.slowlog.threshold.index.info: 5s
+{% if elasticsearch_slowlog_threshold_index_info is defined %}
+index.indexing.slowlog.threshold.index.info: {{ elasticsearch_slowlog_threshold_index_info }}
+{% endif %}
+#index.indexing.slowlog.threshold.index.debug: 2s
+{% if elasticsearch_slowlog_threshold_index_debug is defined %}
+index.indexing.slowlog.threshold.index.debug: {{ elasticsearch_slowlog_threshold_index_debug }}
+{% endif %}
+#index.indexing.slowlog.threshold.index.trace: 500ms
+{% if elasticsearch_slowlog_threshold_index_trace is defined %}
+index.indexing.slowlog.threshold.index.trace: {{ elasticsearch_slowlog_threshold_index_trace }}
+{% endif %}
+
+################################## GC Logging ################################
+
+#monitor.jvm.gc.ParNew.warn: 1000ms
+{% if elasticsearch_gc_par_new_warn is defined %}
+monitor.jvm.gc.ParNew.warn: {{ elasticsearch_gc_par_new_warn }}
+{% endif %}
+#monitor.jvm.gc.ParNew.info: 700ms
+{% if elasticsearch_gc_par_new_info is defined %}
+monitor.jvm.gc.ParNew.info: {{ elasticsearch_gc_par_new_info }}
+{% endif %}
+#monitor.jvm.gc.ParNew.debug: 400ms
+{% if elasticsearch_gc_par_new_debug is defined %}
+monitor.jvm.gc.ParNew.debug: {{ elasticsearch_gc_par_new_debug }}
+{% endif %}
+
+#monitor.jvm.gc.ConcurrentMarkSweep.warn: 10s
+{% if elasticsearch_gc_soncurrent_mark_sweep_warn is defined %}
+monitor.jvm.gc.ConcurrentMarkSweep.warn: {{ elasticsearch_gc_soncurrent_mark_sweep_warn }}
+{% endif %}
+#monitor.jvm.gc.ConcurrentMarkSweep.info: 5s
+{% if elasticsearch_gc_soncurrent_mark_sweep_info is defined %}
+monitor.jvm.gc.ConcurrentMarkSweep.info: {{ elasticsearch_gc_soncurrent_mark_sweep_info }}
+{% endif %}
+#monitor.jvm.gc.ConcurrentMarkSweep.debug: 2s
+{% if elasticsearch_gc_soncurrent_mark_sweep_debug is defined %}
+monitor.jvm.gc.ConcurrentMarkSweep.debug: {{ elasticsearch_gc_soncurrent_mark_sweep_debug }}
+{% endif %}
+
+################################### Varia #####################################
+
+{% if elasticsearch_plugin_marvel_version is defined %}
+
+{% if elasticsearch_plugin_marvel_agent_exporter_es_index_timeformat is defined %}
+marvel.agent.exporter.es.index.timeformat: {{ elasticsearch_plugin_marvel_agent_exporter_es_index_timeformat }}
+{% endif %}
+{% if elasticsearch_plugin_marvel_agent_interval is defined %}
+marvel.agent.interval: {{ elasticsearch_plugin_marvel_agent_interval }}
+{% endif %}
+{% if elasticsearch_plugin_marvel_agent_indices is defined %}
+marvel.agent.indices: {{ elasticsearch_plugin_marvel_agent_indices }}
+{% endif %}
+{% if elasticsearch_plugin_marvel_agent_exporter_es_hosts is defined %}
+marvel.agent.exporter.es.hosts: {{ elasticsearch_plugin_marvel_agent_exporter_es_hosts }}
+{% endif %}
+{% if elasticsearch_plugin_marvel_agent_enabled is defined %}
+marvel.agent.enabled: {{ elasticsearch_plugin_marvel_agent_enabled }}
+{% endif %}
+
+{% endif %}
+
+{% if elasticsearch_misc_auto_create_index is defined %}
+action.auto_create_index: {{ elasticsearch_misc_auto_create_index }}
+{% endif %}
+{% if elasticsearch_misc_disable_delete_all_indices is defined %}
+action.disable_delete_all_indices: {{ elasticsearch_misc_disable_delete_all_indices }}
+{% endif %}
+{% if elasticsearch_thread_pools is defined %}
+{% for threadPoolSetting in elasticsearch_thread_pools %}
+{{ threadPoolSetting }}
+{% endfor %}
+{% endif %}
+
+################################### Dynamic Scripting #####################################
+
+{% if elasticsearch_script_disable_dynamic is defined %}
+script.disable_dynamic: {{ elasticsearch_script_disable_dynamic }}
+{% endif %}
+
+################################### CORS Settings #####################################
+
+{% if elasticsearch_http_cors_enabled is defined %}
+http.cors.enabled: {{ elasticsearch_http_cors_enabled }}
+{% endif %}


### PR DESCRIPTION
- Added new elasticsearch17_download_url variable for ES version 1.7
- Added ESversionGt5 new set_fact variable for ES version greater than 5
- Updated README file: Included ES version 5 and 6 Thread Pools config
- Created new README-examples.md file with examples for Xenial, bionic
and CentOS and ES version 1,5 and 6.
- Removed ES_USER and ES_GROUP for ES version 6
https://www.elastic.co/guide/en/elasticsearch/reference/6.0/breaking_60_packaging_changes.html
- Removed path.conf variable for ES version 6
- Added new CentOS feature to install specific ES version

Connects to https://github.com/artefactual/archivematica/issues/1171