### PR TITLE
Add systemd LimitMEMLOCK

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,10 @@
 ---
 # Elasticsearch Ansible Handlers
 
+# Reload Systemd units
+- name: Reload Systemd units
+  command: systemctl daemon-reload
+
 # Restart Elasticsearch
 - name: Restart Elasticsearch
   service: name=elasticsearch state=restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -124,3 +124,18 @@
 # Register Elasticsearch service to start on boot
 - name: Ensure Elasticsearch is started on boot
   service: name=elasticsearch enabled={{ elasticsearch_service_startonboot }} state={{ elasticsearch_service_state }}
+
+# Create systemd override directory
+- name: Creating systemd override directory
+  file:
+    path: /etc/systemd/system/elasticsearch.service.d
+    state: directory
+  when: ansible_service_mgr == "systemd"
+
+# Configure LimitMEMLock on systemd
+- name: Configuring LimitMEMLock on systemd
+  template: src=elasticsearch.systemd.override.j2 dest=/etc/systemd/system/elasticsearch.service.d/override.conf owner={{ elasticsearch_user }} group={{ elasticsearch_group }} mode=0644
+  when: ansible_service_mgr == "systemd"
+  notify:
+    - Reload Systemd units
+    - Restart Elasticsearch

--- a/templates/elasticsearch.systemd.override.j2
+++ b/templates/elasticsearch.systemd.override.j2
@@ -1,0 +1,8 @@
+[Service]
+{% if elasticsearch_max_locked_memory is defined and elasticsearch_max_locked_memory == 'unlimited' %}
+LimitMEMLOCK=infinity
+{% elif elasticsearch_max_locked_memory is defined %}
+LimitMEMLOCK={{ elasticsearch_max_locked_memory }}
+{% else %}
+#LimitMEMLOCK=infinity
+{% endif %}


### PR DESCRIPTION
When using systemd and memory lock it is needed to enable LimitMEMLOCK at
systemd level.

Connects to archivematica/Issues#379