### PR TITLE
Update defaults to 6.8.3

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,9 +4,11 @@
 elasticsearch_user: elasticsearch
 elasticsearch_group: elasticsearch
 elasticsearch_download_url: https://artifacts.elastic.co/downloads/elasticsearch
-elasticsearch_version: 1.7.6
+elasticsearch_version: "6.8.3"
 elasticsearch_apt_repos: []
-elasticsearch_apt_java_package: default-jre-headless
+elasticsearch_apt_java_package: openjdk-8-jre-headless
+elasticsearch_java_home: "/usr/lib/jvm/java-1.8.0-openjdk-amd64"
+
 elasticsearch_apt_dependencies:
   - htop
   - ntp
@@ -23,9 +25,27 @@ elasticsearch_service_startonboot: yes
 elasticsearch_service_state: started
 elasticsearch_network_bind_host: "127.0.0.1"
 
+
 # Elasticsearch 1.7 Ansible Variables
 
 elasticsearch17_download_url: https://download.elasticsearch.org/elasticsearch/elasticsearch
+
+# Elasticsearch 6.x Ansible Variables
+
+elasticsearch_heap_size: "1g"
+elasticsearch_timezone: "UTC"
+elasticsearch_node_max_local_storage_nodes: "1"
+elasticsearch_memory_bootstrap_mlockall: "true"
+elasticsearch_install_java: "true"
+elasticsearch_thread_pools:
+  - "thread_pool.write.size: 2"
+  - "thread_pool.write.queue_size: 1000"
+elasticsearch_network_http_max_content_lengtht: 1024mb
+elasticsearch_discovery_zen_ping_multicast_enabled: "false"
+elasticsearch_max_locked_memory: "unlimited"
+elasticsearch_network_host: "127.0.0.1"
+elasticsearch_network_bind: "127.0.0.1"
+
 
 # Non-Elasticsearch Defaults
 apt_cache_valid_time: 300 # seconds between "apt-get update" calls.


### PR DESCRIPTION
We need to add a big snippet to our all deployments, because the defaults are outdated.

This PR brings the latest 6.X elasticsearch as the default version.