### PR TITLE
Remove duplicated var

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,5 +49,4 @@ elasticsearch_network_bind: "127.0.0.1"
 
 # Non-Elasticsearch Defaults
 apt_cache_valid_time: 300 # seconds between "apt-get update" calls.
-elasticsearch_install_java: "true"
 install_rpm_repositories: "true"


### PR DESCRIPTION
This gets rid of ansible warning