### PR TITLE
Remove write options from defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,9 +37,6 @@ elasticsearch_timezone: "UTC"
 elasticsearch_node_max_local_storage_nodes: "1"
 elasticsearch_memory_bootstrap_mlockall: "true"
 elasticsearch_install_java: "true"
-elasticsearch_thread_pools:
-  - "thread_pool.write.size: 2"
-  - "thread_pool.write.queue_size: 1000"
 elasticsearch_network_http_max_content_lengtht: 1024mb
 elasticsearch_discovery_zen_ping_multicast_enabled: "false"
 elasticsearch_max_locked_memory: "unlimited"


### PR DESCRIPTION
The write variables are only available for ES version 6, so it is
better to remove this section from defaults to make the default
options compatible with ES version 5 and 6.

Connects to https://github.com/artefactual-labs/ansible-elasticsearch/issues/22