### PR TITLE
Fix deprecation warnings from Ansible 2.9

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -37,14 +37,13 @@
   apt:
     pkg: "{{elasticsearch_apt_java_package}}"
     state: "present"
-  when: elasticsearch_install_java
+  when: elasticsearch_install_java|bool
 
 # Install dependencies
 - name: Install dependencies
   apt:
-    pkg: "{{ item }}"
+    pkg: "{{ elasticsearch_apt_dependencies }}"
     state: "present"
-  with_items: "{{ elasticsearch_apt_dependencies }}"
 
 # Configure user and group
 - name: Configuring user and group


### PR DESCRIPTION
- Use "|bool" to cast var in "when:" conditional
- Pass package list to "apt.pkg" directly instead of using "with_items"