### PR TITLE
Missing package error Ubuntu 20.04

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -23,7 +23,16 @@
     update_cache: "yes"
     cache_valid_time: "{{apt_cache_valid_time}}"
   when:
-    - ansible_distribution_release != "bionic"
+    - ansible_distribution_release == "xenial"
+
+- name: Install software-properties-common
+  apt:
+    pkg: "software-properties-common"
+    state: "present"
+    update_cache: "yes"
+    cache_valid_time: "{{apt_cache_valid_time}}"
+  when:
+    - ansible_distribution_release == "focal"
 
 - name: Update repositories
   apt_repository:


### PR DESCRIPTION
This fix addresses the error:
- "No package matching 'python-software-properties' is available"

Replacing package with software-properties-common when base OS is
Ubuntu 20.04.