### PR TITLE
Refactor 20.04 dependency check

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -23,7 +23,7 @@
     update_cache: "yes"
     cache_valid_time: "{{apt_cache_valid_time}}"
   when:
-    - ansible_distribution_release == "xenial"
+    - ansible_distribution_version is version_compare('18.04', '<=')
 
 - name: Install software-properties-common
   apt:
@@ -32,7 +32,7 @@
     update_cache: "yes"
     cache_valid_time: "{{apt_cache_valid_time}}"
   when:
-    - ansible_distribution_release == "focal"
+    - ansible_distribution_version is version_compare('20.04', '>=')
 
 - name: Update repositories
   apt_repository:


### PR DESCRIPTION
Change dependency check for software-properties-common package
to use Debian version (<= 18.04, >= 20.04 etc) instead of matching
to release ("xenial", "focal"). This logic might prevent future
issues when upgrading to versions > 20.04.