### PR TITLE
Fix Debian version check

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -23,7 +23,7 @@
     update_cache: "yes"
     cache_valid_time: "{{apt_cache_valid_time}}"
   when:
-    - ansible_distribution_version is version_compare('18.04', '<=')
+    - ansible_distribution_version is version_compare('16.04', '<=')
 
 - name: Install software-properties-common
   apt:


### PR DESCRIPTION
The package 'python-software-properties' is only avaible in Ubuntu
<= 16.04. This commit corrects the version comparison to exclude
Ubuntu 18.04.