### PR TITLE
Updated to work with more recent versions of Ansible and Elasticsearch.

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -4,45 +4,47 @@
 # You will need to define an array called 'elasticsearch_plugins' in your playbook or inventory, such that:
 #
 # elasticsearch_plugins:
-#  - { name: '<plugin name>', url: '<[optional] plugin url>' }
+#  - name: '<plugin name>'
+#  - url: '<plugin url>'
 #  - ...
-# where if you were to install the plugin via bin/plugin, you would type:
 #
-# bin/plugin -install <plugin name>
+# where if you were to install the plugin via bin/elasticsearch-plugin, you would type:
 #
-# or
-#
-# bin/plugin -install <plugin name> -url <plugin url>
+# bin/elasticsearch-plugin install -b <plugin name or plugin url>
 
-# Example for https://github.com/elasticsearch/elasticsearch-mapper-attachments (bin/plugin -install elasticsearch/elasticsearch-mapper-attachments/1.9.0):
+# Example for ingest-attachment (bin/elasticsearch-plugin install -b ingest-attachment)
 # elasticsearch_plugins:
-#  - { name: 'elasticsearch/elasticsearch-mapper-attachments/1.9.0' }
+#  - name: 'ingest-attachment'
 #
-# Example for https://github.com/richardwilly98/elasticsearch-river-mongodb (bin/plugin -i com.github.richardwilly98.elasticsearch/elasticsearch-river-mongodb/1.7.1):
+# Example https://github.com/infinilabs/analysis-pinyin (bin/elasticsearch-plugin install -b https://github.com/infinilabs/analysis-pinyin/releases/download/v6.8.23/elasticsearch-analysis-pinyin-6.8.23.zip)
 # elasticsearch_plugins:
-#  - { name: 'com.github.richardwilly98.elasticsearch/elasticsearch-river-mongodb/1.7.1' }
-#
-# Example for https://github.com/imotov/elasticsearch-facet-script (bin/plugin -install facet-script -url http://dl.bintray.com/content/imotov/elasticsearch-plugins/elasticsearch-facet-script-1.1.2.zip):
-# elasticsearch_plugins:
-#  - { name: 'facet-script', url: 'http://dl.bintray.com/content/imotov/elasticsearch-plugins/elasticsearch-facet-script-1.1.2.zip' }
+#  - url: "https://github.com/infinilabs/analysis-pinyin/releases/download/v6.8.21/elasticsearch-analysis-pinyin-6.8.21.zip"
+
+# NOTE: all plugins are installed in batch mode, security permissions confirmed automatically
 
 # Loop though elasticsearch_plugins and install them
+
 - name: Installing Plugins by Name
-  action: >
-    shell bin/plugin -install {{ item.name }}
-    chdir={{ elasticsearch_home_dir }}
+  ansible.builtin.shell: 
+    cmd: bin/elasticsearch-plugin install -b "{{ item.name }}"
+    chdir: "{{ elasticsearch_home_dir }}"
   when: item.url is not defined
-  with_items: elasticsearch_plugins
+  with_items: "{{ elasticsearch_plugins }}"
   ignore_errors: yes
+
 - name: Installing Plugins by URL
-  action: >
-    shell bin/plugin -install {{ item.name }} -url {{ item.url }}
-    chdir={{ elasticsearch_home_dir }}
+  ansible.builtin.shell:
+    cmd: bin/elasticsearch-plugin install -b "{{ item.url }}"
+    chdir: "{{ elasticsearch_home_dir }}"
   when: item.url is defined
-  with_items: elasticsearch_plugins
+  with_items: "{{ elasticsearch_plugins }}"
   ignore_errors: yes
+
 # Fix permissions
-- file: >
-    path="{{ elasticsearch_plugin_dir }}" state=directory
-    owner={{ elasticsearch_user }} group={{ elasticsearch_group }}
-    recurse=yes
+- name: Fix Plugin Directory Permissions 
+  ansible.builtin.file:
+    path: "{{ elasticsearch_plugin_dir }}"
+    state: directory
+    owner: "{{ elasticsearch_user }}"
+    group: "{{ elasticsearch_group }}"
+    recurse: yes


### PR DESCRIPTION
Wanted to automatically install the 'repository-s3' extension for snapshots, noticed that this task was quite broken for the version of elasticsearch currently installed by this role. So here we are.