### PR TITLE
Fix include_tasks and import_tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 # Elasticsearch Ansible Tasks
 
 - name: "Elasticsearch OS dependant packages"
-  include_tasks: "{{ ansible_os_family }}.yml"
+  include_tasks: "{{ ansible_os_family }}.yml"  # Need to use include_tasks instead of import_tasks because it is using {{ ansible_os_family }} so it needs to be load dinamically
 
 # Define auxiliar variable for ES version >= 6.0.0
 - name: Define ESversionGt5 variable when ES version >= 6.0.0
@@ -152,7 +152,7 @@
   when: elasticsearch_version is version_compare('5.0', '>=')
 
 # Patch ES version 5 for cve-2021-44228-vulnerability
-- include_tasks: cve-2021-44228-patch.yml
+- import_tasks: cve-2021-44228-patch.yml
   when:
     - elasticsearch_version is version_compare('2.0', '>')
     - elasticsearch_version is version_compare('6.0', '<')
@@ -160,7 +160,7 @@
     - "cve-2021-44228-patch"
 
 # Patch ES version 1.x for cve-2021-4104-vulnerability
-- include_tasks: cve-2021-4104-patch.yml
+- import_tasks: cve-2021-4104-patch.yml
   when:
     - elasticsearch_version is version_compare('2.0', '<')
   tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 # Elasticsearch Ansible Tasks
 
 - name: "Elasticsearch OS dependant packages"
-  include_tasks: "{{ ansible_os_family }}.yml"  # Need to use include_tasks instead of import_tasks because it is using {{ ansible_os_family }} so it needs to be load dinamically
+  include_tasks: "{{ ansible_os_family }}.yml"  # Need to use include_tasks instead of import_tasks because it is using {{ ansible_os_family }} so it needs to be loaded dinamically
 
 # Define auxiliar variable for ES version >= 6.0.0
 - name: Define ESversionGt5 variable when ES version >= 6.0.0


### PR DESCRIPTION
In previous commit, the obsolete `include` was changed with `include_tasks` and it breaks the role when using tags (always skipped).

This commit use import_tasks when possible, and use include_tasks when needed (dynamic data).