### PR TITLE
Update apt dependencies

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,7 +28,6 @@ elasticsearch_package_extra_version: >-
 
 elasticsearch_apt_dependencies:
   - htop
-  - ntp
   - unzip
 elasticsearch_max_open_files: 65535
 elasticsearch_home_dir: /usr/share/elasticsearch


### PR DESCRIPTION
In Ubuntu 24.04 the role fails with:

```
TASK [artefactual.elasticsearch : Install dependencies] ************************
changed: [am-local]

TASK [artefactual.elasticsearch : Install dependencies] ************************
Error: : Task failed: Module failed: '/usr/bin/apt-get -y -o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold" -o DPkg::Lock::Timeout=60       install 'ntp=1:4.2.8p15+dfsg-2~1.2.2+dfsg1-4build2' 'unzip=6.0-28ubuntu4.1'' failed: E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.

Origin: /home/runner/work/deploy-pub/deploy-pub/playbooks/archivematica-noble/roles/artefactual.elasticsearch/tasks/Debian.yml:54:3

52
53 # Install dependencies
54 - name: Install dependencies
     ^ column 3

fatal: [am-local]: FAILED! => {"cache_update_time": 1753746267, "cache_updated": false, "changed": false, "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\" -o DPkg::Lock::Timeout=60       install 'ntp=1:4.2.8p15+dfsg-2~1.2.2+dfsg1-4build2' 'unzip=6.0-28ubuntu4.1'' failed: E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.\n", "rc": 100, "stderr": "E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.\n", "stderr_lines": ["E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages."], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nSome packages could not be installed. This may mean that you have\nrequested an impossible situation or if you are using the unstable\ndistribution that some required packages have not yet been created\nor been moved out of Incoming.\nThe following information may help to resolve the situation:\n\nThe following packages have unmet dependencies:\n ntpsec : Conflicts: time-daemon\n systemd-timesyncd : Conflicts: time-daemon\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "Some packages could not be installed. This may mean that you have", "requested an impossible situation or if you are using the unstable", "distribution that some required packages have not yet been created", "or been moved out of Incoming.", "The following information may help to resolve the situation:", "", "The following packages have unmet dependencies:", " ntpsec : Conflicts: time-daemon", " systemd-timesyncd : Conflicts: time-daemon"]}

PLAY RECAP *********************************************************************
am-local                   : ok=7    changed=3    unreachable=0    failed=1    skipped=3    rescued=0    ignored=0
```

It seems removing `ntp` from the APT dependencies doesn't have any impact.