### PR TITLE
Add discovery config for ES>7.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,6 +59,11 @@ elasticsearch_max_locked_memory: "unlimited"
 elasticsearch_network_host: "127.0.0.1"
 elasticsearch_network_bind: "127.0.0.1"
 
+# Elasticsearch 7.x Ansible Variables
+
+elasticsearch_discovery_type: "single-node" # Needed when not listening in localhost. Using single-node will disable the discovery
+elasticsearch_discovery_seed_hosts: "[]"
+
 
 # Non-Elasticsearch Defaults
 apt_cache_valid_time: 300 # seconds between "apt-get update" calls.

--- a/templates/elasticsearch5.yml.j2
+++ b/templates/elasticsearch5.yml.j2
@@ -106,6 +106,14 @@ node.max_local_storage_nodes: {{ elasticsearch_node_max_local_storage_nodes }}
 node.local: {{ elasticsearch_node_local }}
 {% endif %}
 
+{% if elasticsearch_version is version_compare('7.0', '>=') %}
+
+discovery.type: {{ elasticsearch_discovery_type }}
+discovery.seed_hosts: {{ elasticsearch_discovery_seed_hosts }}
+
+{% endif %}
+
+
 #################################### Index ####################################
 
 # Since elasticsearch 5.x index level settings can NOT be set on the nodes 


### PR DESCRIPTION
When not using ES in developer mode (not listening in 127.0.0.1), elasticsearch requires to configure the discovery. It is the error before adding this commit

```
Oct 30 08:31:09 atomeurope-es-4 systemd-entrypoint[254421]: ERROR: [1] bootstrap checks failed
Oct 30 08:31:09 atomeurope-es-4 systemd-entrypoint[254421]: [1]: the default discovery settings are unsuitable for production use; at least one of [discovery.seed_hosts, discovery.seed_providers, cluster.initial_master_nodes] must be configured
```

This commit add the variables to configure discovery for ES>7:

* discovery.seed_hosts
* discovery.type