### PR TITLE
Configure max_shards_per_node and disable replica

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,7 +40,13 @@ elasticsearch_service_startonboot: yes
 #elasticsearch_http_cors_enabled: "false"
 elasticsearch_service_state: started
 elasticsearch_network_bind_host: "127.0.0.1"
+elasticsearch_max_shards_per_node: 1000
 
+#Disable replica, useful in single node clusters
+# NOTE: Elasticsearch must be up and running to apply it, so better apply on running elasticsearch server with:
+# "-e elasticsearch_disable_replica=True -t elasticsearch-disable-replica"
+# It applies: curl -s -X PUT "http://localhost:9200/_all/_settings" -H 'Content-Type: application/json' -d '{ "index": { "number_of_replicas": 0 } }'
+elasticsearch_disable_replica: False
 
 # Elasticsearch 1.7 Ansible Variables
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -185,3 +185,22 @@
   notify:
     - Reload Systemd units
     - Restart Elasticsearch
+
+# Disable replica, recommended for single node cluster
+# NOTE: Elasticsearch must be up and running to apply it, so better apply on running elasticsearch server with: "-e elasticsearch_disable_replica=True -t elasticsearch-disable-replica"
+- name: Disable elasticsearch replica in all nodes
+  uri:
+    url: "http://localhost:9200/_all/_settings"
+    method: PUT
+    headers:
+      Content-Type: "application/json"
+    body_format: json
+    body:
+      index:
+        number_of_replicas: 0
+    status_code: 200
+  failed_when: false
+  changed_when: false
+  when: elasticsearch_disable_replica|bool
+  tags:
+    - "elasticsearch-disable-replica"

--- a/templates/elasticsearch5.yml.j2
+++ b/templates/elasticsearch5.yml.j2
@@ -29,6 +29,15 @@
 cluster.name: {{ elasticsearch_cluster_name }}
 {% endif %}
 
+{% if elasticsearch_version is version_compare('6.5', '>=') and elasticsearch_max_shards_per_node|int != 1000 %}
+# Maximum number of shards allowed per node.
+# NOTE 1: This setting was introduced in ES 6.5.0 and 7.0+ as a safeguard.
+#         It is NOT supported in Elasticsearch 5.x.
+# NOTE 2: This is only explicitly set here when the value differs from the
+#         built-in default of 1000 to keep the configuration file clean.
+cluster.max_shards_per_node: {{ elasticsearch_max_shards_per_node }}
+{% endif %}
+
 #################################### Node #####################################
 
 # Node names are generated dynamically on startup, so you're relieved


### PR DESCRIPTION
- Added elasticsearch_max_shards_per_node and a conditional cluster.max_shards_per_node output for ES ≥ 6.5.

- Added an optional task to set number_of_replicas: 0 on all indices via the ES HTTP API.