### PR TITLE
Add libxcrypt-compat osdep for RH and ES<7.0

### DIFF
--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -121,6 +121,16 @@
     state: "installed"
     update_cache: true
 
+- name: "Install 6.x deps"
+  yum:
+    name:
+      - "libxcrypt-compat"
+    state: "installed"
+    update_cache: true
+  when:
+    - elasticsearch_version is version_compare('7.0', '<')
+    - ansible_distribution_version is version('9.0', '>=')
+
 - name: "Install Elasticsearch package from repo"
   yum:
     name:


### PR DESCRIPTION
The libxcrypt-compat is needed by Elasticsearch 6 in Rocky 9. It depends on old `libcrypt.so.1`, and offcial package requires the compat library for old binaries.

Tested using ldd on:

* /usr/share/elasticsearch/modules/x-pack-ml/platform/linux-x86_64/bin/controller

Connects to https://github.com/artefactual-labs/ansible-elasticsearch/issues/49